### PR TITLE
Add serialization of quoted triples

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -621,7 +621,8 @@ _:b1,123</pre>
         title="should">should</em> be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label
         indicates the same blank node within the result set, but has no significance outside the result set.</p>
-      <p>Quoted triples are enclosed in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
+      <p>Quoted triples are enclosed in double angle brackets, <code>&lt;&lt; &gt;&gt;</code>,
+      as in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character

--- a/spec/index.html
+++ b/spec/index.html
@@ -522,7 +522,8 @@ span.cancast:hover { background-color: #ffa;
         without syntax to denote what kind of term it is. The encoding quoting rules of CSV format must be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label indicates the
         same blank node within the result set but has no significance outside the result set.</p>
-      <p>Quoted triples are enclosed in <code>&lt;&lt; <em>subject</em> <em>predicate</em> <em>object</em> &gt;&gt;</code>,
+      <p>Quoted triples are enclosed in double angle brackets, <code>&lt;&lt; &gt;&gt;</code>,
+      as <code>&lt;&lt; <em>subject</em> <em>predicate</em> <em>object</em> &gt;&gt;</code>,
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character

--- a/spec/index.html
+++ b/spec/index.html
@@ -463,7 +463,7 @@ span.cancast:hover { background-color: #ffa;
           <tr>
             <td>"Carol"</td>
             <td>&lt;&lt; &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"."&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/carol</code> predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/carol</code>, predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
           </tr>
         </tbody>
       </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -541,9 +541,9 @@ span.cancast:hover { background-color: #ffa;
         end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.
         This quoting mechanism is applied recursively for terms in quoted triples.</p>
       <p id="csv-terms-escaping" class="note">
-        Since quoted triples with literals in the object position are encapsulated within a pair of quotation marks <code>""</code>,
-        the full quoted triple will always be encapsulated within quotation marks as well,
-        which requires the subsequent escaping of the quotation marks encapsulating the literal.
+        Since literals in the object position of quoted triples are encapsulated within a pair of quotation marks <code>"</code>, and
+        the full quoted triple is always encapsulated within quotation marks as well,
+        this requires the subsequent escaping of the "inner" quotation marks encapsulating the literal.
         Such cases will result in quoted triples in the form of <code>"&lt;&lt; <em>subject</em> <em>predicate</em> ""<em>object-literal</em>"" &gt;&gt;"</code>.</p>
       <p>The standard CSV format does not distinguish between missing values and empty strings. The SPARQL 1.2
         Results CSV Format uses the same representation for unbound variables as for variables bound to an empty

--- a/spec/index.html
+++ b/spec/index.html
@@ -458,7 +458,7 @@ span.cancast:hover { background-color: #ffa;
           <tr>
             <td>"Bob"</td>
             <td>&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
           </tr>
           <tr>
             <td>"Carol"</td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -537,7 +537,7 @@ span.cancast:hover { background-color: #ffa;
         <code>U+000A</code>) or <code>CR</code> (code point 13, <code>U+000D</code>) must be quoted using the quoting
         mechanism of RFC4180 [[RFC4180]].
         Fields are limited by a pair of quotation marks <code>"</code> (code point <code>U+0022</code>). Within quote strings, all
-        characters except <code>"</code>, including new line characters have their exact meaning — newlines do not
+        characters except <code>"</code>, including new line characters, have their exact meaning — newlines do not
         end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.
         This quoting mechanism is applied recursively for terms in quoted triples.</p>
       <p id="csv-terms-escaping" class="note">

--- a/spec/index.html
+++ b/spec/index.html
@@ -441,10 +441,7 @@ span.cancast:hover { background-color: #ffa;
           </tr>
         </tbody>
       </table>
-      </section>
 
-      <section id="example2-quoted">
-      <h3>Example with Quoted Triples</h3>
       <p>The following artificial example is used to illustrate the features of serializing results containing quoted triples.</p>
       <table class="result">
         <tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -455,12 +455,12 @@ span.cancast:hover { background-color: #ffa;
           </tr>
           <tr>
             <td>"Alice"</td>
-            <td>&lt;&lt;&lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt;&gt;&gt;</td>
+            <td>&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;</td>
             <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/alice</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
           </tr>
           <tr>
             <td>"Bob"</td>
-            <td>&lt;&lt;&lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt;&gt;&gt;</td>
+            <td>&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</td>
             <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
           </tr>
         </tbody>
@@ -520,11 +520,12 @@ span.cancast:hover { background-color: #ffa;
         without syntax to denote what kind of term it is. The encoding quoting rules of CSV format must be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label indicates the
         same blank node within the result set but has no significance outside the result set.</p>
-      <p>Quoted triples are enclosed in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
+      <p>Quoted triples are enclosed in <code>&lt;&lt; <em>subject</em> <em>predicate</em> <em>object</em> &gt;&gt;</code>,
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
-         (<small>SPACE</small>, code point 32, <code>U+0020</code>).</p>
+         (<small>SPACE</small>, code point 32, <code>U+0020</code>). The single space character preceding <em>subject</em>,
+         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.</p>
       <p>Fields containing any of <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in 
         Unicode [[UNICODE]]),
         <code>,</code> (<small>COMMA</small>, code point 44, <code>U+002C</code>), <code>LF</code> (code point 10,
@@ -555,8 +556,8 @@ _:b1,123</pre>
       <section id="csv-example-quoted">
       <h3>Example of CSV-Serialized Results with Quoted Triples</h3>
       <pre class="box csv nohighlight">x,quoted
-"Alice",&lt;&lt;http://example/alice http://example/knows http://example/bob&gt;&gt;
-"Bob",&lt;&lt;http://example/bob http://example/knows http://example/alice&gt;&gt;</pre>
+"Alice",&lt;&lt; http://example/alice http://example/knows http://example/bob &gt;&gt;
+"Bob",&lt;&lt; http://example/bob http://example/knows http://example/alice &gt;&gt;</pre>
       </section>
     </section>
 
@@ -612,7 +613,8 @@ _:b1,123</pre>
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
-         (<small>SPACE</small>, code point 32, <code>U+0020</code>).</p>
+         (<small>SPACE</small>, code point 32, <code>U+0020</code>). The single space character preceding <em>subject</em>,
+         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.</p>
       </section>
 
       <section id="tsv-example">
@@ -635,8 +637,8 @@ _:blank1&lt;TAB&gt;123</pre>
       <h3>Example of TSV-Serialized Results with Quoted Triples</h3>
       <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
       <pre class="box tsv nohighlight">?x&lt;TAB&gt;?quoted
-"Alice"&lt;TAB&gt;&lt;&lt;&lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt;&gt;&gt;
-"Bob"&lt;TAB&gt;&lt;&lt;&lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt;&gt;&gt;</pre>
+"Alice"&lt;TAB&gt;&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;
+"Bob"&lt;TAB&gt;&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</pre>
       </section>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -453,7 +453,7 @@ span.cancast:hover { background-color: #ffa;
           <tr>
             <td>"Alice"</td>
             <td>&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/alice</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/alice</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
           </tr>
           <tr>
             <td>"Bob"</td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -531,12 +531,14 @@ span.cancast:hover { background-color: #ffa;
          and the single space character following <em>object</em> are optional, and are mainly valuable for human readability.
          If the <em>object</em> is a literal, then it <em class="rfc2119" title="must">must</em> be encapsulated within
          a pair of quotation marks <code>""</code>.</p>
-      <p>Fields containing any of <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in 
-        Unicode [[UNICODE]]),
-        <code>,</code> (<small>COMMA</small>, code point 44, <code>U+002C</code>), <code>LF</code> (code point 10,
-        <code>U+000A</code>) or <code>CR</code> (code point 13, <code>U+000D</code>) must be quoted using the quoting
+      <p>Fields containing any of 
+        <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in Unicode [[UNICODE]]),
+        <code>,</code> (<small>COMMA</small>, code point 44, <code>U+002C</code>),
+        <code>LF</code> (code point 10, <code>U+000A</code>), or
+        <code>CR</code> (code point 13, <code>U+000D</code>)
+        <em class="rfc2119" title="must">must</em> be quoted using the quoting
         mechanism of RFC4180 [[RFC4180]].
-        Fields are limited by a pair of quotation marks <code>"</code> (code point <code>U+0022</code>). Within quote strings, all
+        Fields are delimited by a pair of quotation marks <code>"</code> (code point <code>U+0022</code>). Within quoted strings, all
         characters except <code>"</code>, including new line characters, have their exact meaning — newlines do not
         end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.
         This quoting mechanism is applied recursively for terms in quoted triples.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -528,7 +528,7 @@ span.cancast:hover { background-color: #ffa;
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
          (<small>SPACE</small>, code point 32, <code>U+0020</code>). The single space character preceding <em>subject</em>,
-         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.
+         and the single space character following <em>object</em> are optional, and are mainly valuable for human readability.
          If the <em>object</em> is a literal, then it <em class="rfc2119" title="must">must</em> be encapsulated within
          a pair of quotation marks <code>""</code>.</p>
       <p>Fields containing any of <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in 

--- a/spec/index.html
+++ b/spec/index.html
@@ -442,6 +442,30 @@ span.cancast:hover { background-color: #ffa;
         </tbody>
       </table>
       </section>
+
+      <section id="example2-quoted">
+      <h3>Example with Quoted Triples</h3>
+      <p>The following artificial example is used to illustrate the features of serializing results containing quoted triples.</p>
+      <table class="result">
+        <tbody>
+          <tr>
+            <th>x</th>
+            <th>quoted</th>
+            <th class="tablecomment"><i>Comment (not part of the table)</i></th>
+          </tr>
+          <tr>
+            <td>"Alice"</td>
+            <td>&lt;&lt;&lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt;&gt;&gt;</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/alice</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
+          </tr>
+          <tr>
+            <td>"Bob"</td>
+            <td>&lt;&lt;&lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt;&gt;&gt;</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
+          </tr>
+        </tbody>
+      </table>
+      </section>
     </section>
     <section id="general-comments">
     <h2>Transmission issues using CSV and TSV Formats</h2>
@@ -470,6 +494,7 @@ span.cancast:hover { background-color: #ffa;
             <li>URIs</li>
             <li>lexical forms of non-numeric XSD datatypes</li>
             <li>blank node labels</li>
+            <li>quoted triples</li>
           </ul>
         </li>
         <li>numbers for literals of numeric XSD datatypes</li>
@@ -495,6 +520,11 @@ span.cancast:hover { background-color: #ffa;
         without syntax to denote what kind of term it is. The encoding quoting rules of CSV format must be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label indicates the
         same blank node within the result set but has no significance outside the result set.</p>
+      <p>Quoted triples are enclosed in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
+         where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
+         The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
+         <em class="rfc2119" title="must">must</em> be separated by a single space character
+         (<small>SPACE</small>, code point 32, <code>U+0020</code>).</p>
       <p>Fields containing any of <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in 
         Unicode [[UNICODE]]),
         <code>,</code> (<small>COMMA</small>, code point 44, <code>U+002C</code>), <code>LF</code> (code point 10,
@@ -521,13 +551,20 @@ http://example/x,
 _:b1,String-with-lang
 _:b1,123</pre>
       </section>
+
+      <section id="csv-example-quoted">
+      <h3>Example of CSV-Serialized Results with Quoted Triples</h3>
+      <pre class="box csv nohighlight">x,quoted
+"Alice",&lt;&lt;http://example/alice http://example/knows http://example/bob&gt;&gt;
+"Bob",&lt;&lt;http://example/bob http://example/knows http://example/alice&gt;&gt;</pre>
+      </section>
     </section>
 
     <section id="tsv">
     <h2>TSV — Tab Separated values</h2>
     <p>In the SPARQL Results TSV Format, the results table is serialized as one line listing the variables
       in the results, followed by one line for each query solution. All RDF terms used in the format are
-      encoded in the format specified by Turtle [[RDF12-TURTLE]
+      encoded in the format specified by Turtle [RDF12-TURTLE]
       except that the triple quoted forms for the lexical part of
       literals <em class="rfc2119" title="must not">must not</em> be used. These forms would allow raw
       newlines and tabs that are part of the TSV format. A TSV format SPARQL result set must use the
@@ -571,6 +608,11 @@ _:b1,123</pre>
         title="should">should</em> be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label
         indicates the same blank node within the result set, but has no significance outside the result set.</p>
+      <p>Quoted triples are enclosed in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
+         where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
+         The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
+         <em class="rfc2119" title="must">must</em> be separated by a single space character
+         (<small>SPACE</small>, code point 32, <code>U+0020</code>).</p>
       </section>
 
       <section id="tsv-example">
@@ -587,6 +629,14 @@ _:blank0&lt;TAB&gt;"Blank node"
 &lt;http://example/x&gt;&lt;TAB&gt;
 _:blank1&lt;TAB&gt;"String-with-lang"@en
 _:blank1&lt;TAB&gt;123</pre>
+      </section>
+
+      <section id="tsv-example-quoted">
+      <h3>Example of TSV-Serialized Results with Quoted Triples</h3>
+      <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
+      <pre class="box tsv nohighlight">?x&lt;TAB&gt;?quoted
+"Alice"&lt;TAB&gt;&lt;&lt;&lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt;&gt;&gt;
+"Bob"&lt;TAB&gt;&lt;&lt;&lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt;&gt;&gt;</pre>
       </section>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -460,6 +460,11 @@ span.cancast:hover { background-color: #ffa;
             <td>&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</td>
             <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code> predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
           </tr>
+          <tr>
+            <td>"Carol"</td>
+            <td>&lt;&lt; &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"."&gt;</td>
+            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/carol</code> predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
+          </tr>
         </tbody>
       </table>
       </section>
@@ -522,7 +527,9 @@ span.cancast:hover { background-color: #ffa;
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
          (<small>SPACE</small>, code point 32, <code>U+0020</code>). The single space character preceding <em>subject</em>,
-         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.</p>
+         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.
+         If the <em>object</em> is a literal, then it <em class="rfc2119" title="must">must</em> be encapsulated within
+         a pair of quotation marks <code>""</code>.</p>
       <p>Fields containing any of <code>"</code> (<small>QUOTATION MARK</small>, code point 34, <code>U+0022</code> in 
         Unicode [[UNICODE]]),
         <code>,</code> (<small>COMMA</small>, code point 44, <code>U+002C</code>), <code>LF</code> (code point 10,
@@ -530,7 +537,13 @@ span.cancast:hover { background-color: #ffa;
         mechanism of RFC4180 [[RFC4180]].
         Fields are limited by a pair of quotation marks <code>"</code> (code point <code>U+0022</code>). Within quote strings, all
         characters except <code>"</code>, including new line characters have their exact meaning — newlines do not
-        end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.</p>
+        end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.
+        This quoting mechanism is applied recursively for terms in quoted triples.</p>
+      <p id="csv-terms-escaping" class="note">
+        Since quoted triples with literals in the object position are encapsulated within a pair of quotation marks <code>""</code>,
+        the full quoted triple will always be encapsulated within quotation marks as well,
+        which requires the subsequent escaping of the quotation marks encapsulating the literal.
+        Such cases will result in quoted triples in the form of <code>"&lt;&lt; <em>subject</em> <em>predicate</em> ""<em>object-literal</em>"" &gt;&gt;"</code>.</p>
       <p>The standard CSV format does not distinguish between missing values and empty strings. The SPARQL 1.2
         Results CSV Format uses the same representation for unbound variables as for variables bound to an empty
         string literal. The other SPARQL Result formats (based on JSON, TSV, or XML) can be used if this distinction
@@ -554,7 +567,8 @@ _:b1,123</pre>
       <h3>Example of CSV-Serialized Results with Quoted Triples</h3>
       <pre class="box csv nohighlight">x,quoted
 "Alice",&lt;&lt; http://example/alice http://example/knows http://example/bob &gt;&gt;
-"Bob",&lt;&lt; http://example/bob http://example/knows http://example/alice &gt;&gt;</pre>
+"Bob",&lt;&lt; http://example/bob http://example/knows http://example/alice &gt;&gt;
+"Carol","&lt;&lt; http://example/carol http://example/says ""Hello world, my name is """"Alice""""."" &gt;&gt;"</pre>
       </section>
     </section>
 
@@ -635,7 +649,8 @@ _:blank1&lt;TAB&gt;123</pre>
       <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
       <pre class="box tsv nohighlight">?x&lt;TAB&gt;?quoted
 "Alice"&lt;TAB&gt;&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;
-"Bob"&lt;TAB&gt;&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</pre>
+"Bob"&lt;TAB&gt;&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;
+"Carol"&lt;TAB&gt;&lt;&lt; &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\". &gt;&gt;</pre>
       </section>
     </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -627,7 +627,7 @@ _:b1,123</pre>
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
          (<small>SPACE</small>, code point 32, <code>U+0020</code>). The single space character preceding <em>subject</em>,
-         and the single space character following <em>object</em> are optional, which are mainly valuable for human readability.</p>
+         and the single space character following <em>object</em> are optional, and are mainly valuable for human readability.</p>
       </section>
 
       <section id="tsv-example">


### PR DESCRIPTION
Closes #18


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/pull/24.html" title="Last updated on Jun 26, 2023, 7:16 AM UTC (17436aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/24/a7809d8...17436aa.html" title="Last updated on Jun 26, 2023, 7:16 AM UTC (17436aa)">Diff</a>