### PR TITLE
Migrate from quoted triples to triple terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -447,28 +447,28 @@ span.cancast:hover { background-color: #ffa;
         </tbody>
       </table>
 
-      <p>The following artificial example is used to illustrate the features of serializing results containing quoted triples.</p>
+      <p>The following artificial example is used to illustrate the features of serializing results containing triple terms.</p>
       <table class="result">
         <tbody>
           <tr>
             <th>x</th>
-            <th>quoted</th>
+            <th>triple</th>
             <th class="tablecomment"><i>Comment (not part of the table)</i></th>
           </tr>
           <tr>
             <td>"Alice"</td>
-            <td>&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/alice</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
+            <td>&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;</td>
+            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/alice</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
           </tr>
           <tr>
             <td>"Bob"</td>
-            <td>&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/bob</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
+            <td>&lt;&lt;( &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; )&gt;&gt;</td>
+            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/bob</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
           </tr>
           <tr>
             <td>"Carol"</td>
-            <td>&lt;&lt; &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"."&gt;</td>
-            <td class="tablecomment">A plain string and quoted triple with subject IRI <code>http://example/carol</code>, predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
+            <td>&lt;&lt;( &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"." )&gt;&gt;</td>
+            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/carol</code>, predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
           </tr>
         </tbody>
       </table>
@@ -501,7 +501,7 @@ span.cancast:hover { background-color: #ffa;
             <li>URIs</li>
             <li>lexical forms of non-numeric XSD datatypes</li>
             <li>blank node labels</li>
-            <li>quoted triples</li>
+            <li>triple terms</li>
           </ul>
         </li>
         <li>numbers for literals of numeric XSD datatypes</li>
@@ -527,8 +527,8 @@ span.cancast:hover { background-color: #ffa;
         without syntax to denote what kind of term it is. The encoding quoting rules of CSV format must be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label indicates the
         same blank node within the result set but has no significance outside the result set.</p>
-      <p>Quoted triples are enclosed in double angle brackets, <code>&lt;&lt; &gt;&gt;</code>,
-      as <code>&lt;&lt; <em>subject</em> <em>predicate</em> <em>object</em> &gt;&gt;</code>,
+      <p>Triple terms are enclosed in <code>&lt;&lt;( &mldr; )&gt;&gt;</code>,
+      as <code>&lt;&lt;( <em>subject</em> <em>predicate</em> <em>object</em> )&gt;&gt;</code>,
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
@@ -546,12 +546,12 @@ span.cancast:hover { background-color: #ffa;
         Fields are delimited by a pair of quotation marks <code>"</code> (code point <code>U+0022</code>). Within quoted strings, all
         characters except <code>"</code>, including new line characters, have their exact meaning — newlines do not
         end a CSV record. Inline <code>"</code> is written using a pair of quotation marks <code>""</code>.
-        This quoting mechanism is applied recursively for terms in quoted triples.</p>
+        This quoting mechanism is applied recursively for terms in triple terms.</p>
       <p id="csv-terms-escaping" class="note">
-        Since literals in the object position of quoted triples are encapsulated within a pair of quotation marks <code>"</code>, and
-        the full quoted triple is always encapsulated within quotation marks as well,
+        Since literals in the object position of triple terms are encapsulated within a pair of quotation marks <code>"</code>, and
+        the full triple term is always encapsulated within quotation marks as well,
         this requires the subsequent escaping of the "inner" quotation marks encapsulating the literal.
-        Such cases will result in quoted triples in the form of <code>"&lt;&lt; <em>subject</em> <em>predicate</em> ""<em>object-literal</em>"" &gt;&gt;"</code>.</p>
+        Such cases will result in triple terms in the form of <code>"&lt;&lt;( <em>subject</em> <em>predicate</em> ""<em>object-literal</em>"" )&gt;&gt;"</code>.</p>
       <p>The standard CSV format does not distinguish between missing values and empty strings. The SPARQL 1.2
         Results CSV Format uses the same representation for unbound variables as for variables bound to an empty
         string literal. The other SPARQL Result formats (based on JSON, TSV, or XML) can be used if this distinction
@@ -572,12 +572,12 @@ _:b1,String-with-lang-dir
 _:b1,123</pre>
       </section>
 
-      <section id="csv-example-quoted">
-      <h3>Example of CSV-Serialized Results with Quoted Triples</h3>
-      <pre class="box csv nohighlight">x,quoted
-"Alice",&lt;&lt; http://example/alice http://example/knows http://example/bob &gt;&gt;
-"Bob",&lt;&lt; http://example/bob http://example/knows http://example/alice &gt;&gt;
-"Carol","&lt;&lt; http://example/carol http://example/says ""Hello world, my name is """"Alice""""."" &gt;&gt;"</pre>
+      <section id="csv-example-triple-terms">
+      <h3>Example of CSV-Serialized Results with Triple Terms</h3>
+      <pre class="box csv nohighlight">x,triple
+"Alice",&lt;&lt;( http://example/alice http://example/knows http://example/bob )&gt;&gt;
+"Bob",&lt;&lt;( http://example/bob http://example/knows http://example/alice )&gt;&gt;
+"Carol","&lt;&lt;( http://example/carol http://example/says ""Hello world, my name is """"Alice""""."" )&gt;&gt;"</pre>
       </section>
     </section>
 
@@ -586,7 +586,7 @@ _:b1,123</pre>
     <p>In the SPARQL Results TSV Format, the results table is serialized as one line listing the variables
       in the results, followed by one line for each query solution. All RDF terms used in the format are
       encoded in the format specified by Turtle [RDF12-TURTLE]
-      except that the triple quoted forms for the lexical part of
+      except that the triple term forms for the lexical part of
       literals <em class="rfc2119" title="must not">must not</em> be used. These forms would allow raw
       newlines and tabs that are part of the TSV format. A TSV format SPARQL result set must use the
       single quoted literal forms, together with any necessary escapes such as <code>\t</code>, 
@@ -629,8 +629,8 @@ _:b1,123</pre>
         title="should">should</em> be used.</p>
       <p>Blank nodes use the <code>_:label</code> form from Turtle and SPARQL. Use of the same label
         indicates the same blank node within the result set, but has no significance outside the result set.</p>
-      <p>Quoted triples are enclosed in double angle brackets, <code>&lt;&lt; &gt;&gt;</code>,
-      as in <code>&lt;&lt;<em>subject</em> <em>predicate</em> <em>object</em>&gt;&gt;</code>,
+      <p>Triple terms are enclosed in <code>&lt;&lt;( &mldr; )&gt;&gt;</code>,
+      as in <code>&lt;&lt;(<em>subject</em> <em>predicate</em> <em>object</em>)&gt;&gt;</code>,
          where the <em>subject</em>, <em>predicate</em>, and <em>object</em> terms are recursively serialized.
          The serializations of <em>subject</em>, <em>predicate</em>, and <em>object</em>
          <em class="rfc2119" title="must">must</em> be separated by a single space character
@@ -655,13 +655,13 @@ _:blank1&lt;TAB&gt;"String-with-lang-dir"@en--ltr
 _:blank1&lt;TAB&gt;123</pre>
       </section>
 
-      <section id="tsv-example-quoted">
-      <h3>Example of TSV-Serialized Results with Quoted Triples</h3>
+      <section id="tsv-example-triple-terms">
+      <h3>Example of TSV-Serialized Results with Triple Terms</h3>
       <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
-      <pre class="box tsv nohighlight">?x&lt;TAB&gt;?quoted
-"Alice"&lt;TAB&gt;&lt;&lt; &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; &gt;&gt;
-"Bob"&lt;TAB&gt;&lt;&lt; &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; &gt;&gt;
-"Carol"&lt;TAB&gt;&lt;&lt; &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\". &gt;&gt;</pre>
+      <pre class="box tsv nohighlight">?x&lt;TAB&gt;?triple
+"Alice"&lt;TAB&gt;&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;
+"Bob"&lt;TAB&gt;&lt;&lt;( &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; )&gt;&gt;
+"Carol"&lt;TAB&gt;&lt;&lt;( &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\". )&gt;&gt;</pre>
       </section>
     </section>
 
@@ -672,7 +672,7 @@ _:blank1&lt;TAB&gt;123</pre>
     <section id="changes-1-1" class="appendix informative">
       <h2>Changes between SPARQL 1.1 Query Results CSV and TSV Formats and SPARQL 1.2 Query Results CSV and TSV Formats</h2>
       <ul>
-        <li>Allow quoted triples to be expressed in <a href="#csv-terms" class="sectionRef"></a> and <a href="#tsv-terms" class="sectionRef"></a></li>
+        <li>Allow triple terms to be expressed in <a href="#csv-terms" class="sectionRef"></a> and <a href="#tsv-terms" class="sectionRef"></a></li>
         <li>Support directional language-tagged strings in <a href="#csv-terms" class="sectionRef"></a> and <a href="#tsv-terms" class="sectionRef"></a></li>
       </ul>
     </section>


### PR DESCRIPTION
Following the changes in https://github.com/w3c/rdf-concepts/commit/6b7ea76dccfa4ec0d5c9b94cdce7d22dcc0536e5, this PR uses triple terms instead of quoted triples.

Related to https://github.com/w3c/sparql-query/pull/149


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/pull/34.html" title="Last updated on Aug 12, 2024, 7:14 AM UTC (732468f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/34/21792af...732468f.html" title="Last updated on Aug 12, 2024, 7:14 AM UTC (732468f)">Diff</a>