### PR TITLE
Adds dark mode and simplify CSS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -51,7 +51,7 @@
         border-collapse: collapse;
       }
 
-      .result > th, td {
+      .result th , .result td {
         border: 1px solid;
         padding-inline: 0.5em;
       }

--- a/spec/index.html
+++ b/spec/index.html
@@ -45,17 +45,6 @@
         lint: { "no-unused-dfns": false }
       };
     </script>
-
-    <style>
-      table.result {
-        border-collapse: collapse;
-      }
-
-      .result th , .result td {
-        border: 1px solid;
-        padding-inline: 0.5em;
-      }
-    </style>
   </head>
   <body>
     <section id="abstract">
@@ -106,13 +95,15 @@
       <section id="example1">
       <h3>Example</h3>
       <p>The following artificial example is used to illustrate the features of serializing results in each format.</p>
-      <table class="result">
-        <tbody>
+      <table class="data">
+        <thead>
           <tr>
             <th>x</th>
             <th>literal</th>
             <th><i>Comment (not part of the table)</i></th>
           </tr>
+        </thead>
+        <tbody>
           <tr>
             <td><code>&lt;http://example/x&gt;</code></td>
             <td><code>String</code></td>
@@ -162,13 +153,15 @@
       </table>
 
       <p>The following artificial example is used to illustrate the features of serializing results containing triple terms.</p>
-      <table class="result">
-        <tbody>
+      <table class="data">
+        <thead>
           <tr>
             <th>x</th>
             <th>triple</th>
             <th><i>Comment (not part of the table)</i></th>
           </tr>
+        </thead>
+        <tbody>
           <tr>
             <td><code>"Alice"</code></td>
             <td><code>&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;</code></td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -45,6 +45,17 @@
         lint: { "no-unused-dfns": false }
       };
     </script>
+
+    <style>
+      table.result {
+        border-collapse: collapse;
+      }
+
+      .result > th, td {
+        border: 1px solid;
+        padding-inline: 0.5em;
+      }
+    </style>
   </head>
   <body>
     <section id="abstract">
@@ -95,7 +106,7 @@
       <section id="example1">
       <h3>Example</h3>
       <p>The following artificial example is used to illustrate the features of serializing results in each format.</p>
-      <table>
+      <table class="result">
         <tbody>
           <tr>
             <th>x</th>
@@ -151,7 +162,7 @@
       </table>
 
       <p>The following artificial example is used to illustrate the features of serializing results containing triple terms.</p>
-      <table>
+      <table class="result">
         <tbody>
           <tr>
             <th>x</th>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <title>SPARQL 1.2 Query Results CSV and TSV Formats</title>
 
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
@@ -44,294 +45,6 @@
         lint: { "no-unused-dfns": false }
       };
     </script>
-
-    <style>
-      /* @import url("local.css"); */
-      /* Inlined to make preview work */
-
-/* CSS For SPARQL Query */
-
-/* In-progress working draft artifacts - to be removed eventually */
-  .issue	{ background-color: #fdd;
-                  font-size: 88% ; }
-  .add		{ background-color: #7fff7f }
-  .remove	{ background-color: #ff7f7f }
-ul.issue	{}
-  .issueBlock	{ margin: 1em 4em 1em 2.5em ; /* Top Right Bottom Left */
-                  padding: 1ex;
-	          /*overflow: auto;*/
-                  page-break-inside: avoid ; }
-  .issueTopic	{ font-weight: bold ; }
-
- .todo		{ font-size: 80% ; color: #444 ; }
-p.todo		{}
-
-.wgNote	{ border: 0.2em solid red;
-      padding: 0.5em ;
-      margin: 1em 4em 1em 2em ; }
-
-.box     { border: thin solid #888888;
-           page-break-inside: avoid ;
-           background-color: #F8F8F8 ; padding:1em ;
-           margin-left:0 ; margin-right: 2ex; 
-           margin-top: 0.1ex ; margin-bottom: 0.1ex ;
-         }
-
-/* Misc WD stuff */
-span.cvs-id     {color: gray; font-size:80%; display: block; }
-
-/* == General Tag Treatment == */
-pre		 { margin: 1em 4em 1em 2.5em ; /* Top Right Bottom Left */
-                   padding: 1ex;
-	           /*overflow: auto;*/
-                   page-break-inside: avoid ; }
-
-/* Tables */
-table, td	{ text-align: left; }
-td, th   { border-style: solid;
-                  border-width: 1px;
-                  border-color: black;
-                  border-bottom-color: gray;
-                  border-right-color: gray; }
-td.annotation, th.annotation { border-style: none; border-bottom-style: dotted; }
-table.plain	{ border-spacing: 0px; padding: 0px ; border-collapse: collapse ; }
-                  /* cellpadding="0" cellspacing="1" style="border-collapse: collapse */
-
-
-th.major	{ background-color: #005a9c;
-                  color: white; }
-.subHeading	{ text-align: left;
-                  background-color: #CCCCCC; }
-th, td		{ padding: 3px; }
-td		{ font-size: 85%; }
-th a:link	{ text-decoration: none; }
-th a:hover	{ background-color:#FFFF99;
-                  text-decoration: underline; }
-
-/* == Prototypes == */
-pre.prototype	{ background-color:#f7f8ff;
-                  border:thin solid #8888aa;
-                  margin: 1em 4em 1em 0em ; }
-.return, .type	{ color: #177 }
-
-/* Definitions */
-.defn		{ margin-left:0 ; margin-right: 2ex; 
-                  margin-top: 0.1ex ; margin-bottom: 0.1ex ;
-                  /*border: double 1px #888888; *//* Buggy */
-                  border: thin solid #888888;
-                  padding: 1ex 2ex 0.5ex 2ex ; /* top, right, bottom, left */
-                  page-break-inside: avoid ;
-                  background-color: #F0F8F8 ; }
-div.defn p	{ margin-top: 1ex ; margin-bottom: 1.5ex ;}
-div.defn ul	{ margin-top: 1ex ; margin-bottom: 1.5ex ; }
-@media print	{ .defn { margin: 1em 1em 1em 1em ; } }
-span.definedTerm	{font-weight: bold;}
-
-div.grammarExtract
-                { border: thin solid #888888;
-                  padding: 1ex 2ex 1ex 2ex ; /* top, right, bottom, left */
-                  margin: 1em 6em 1em 2em ; 
-                  page-break-inside: avoid ;
-                  background-color: #F8F8F8 ; }
-
-pre.codeBlock  { font-family:monospace ; page-break-inside: avoid ; 
-                 margin: 0 ;
-	         margin-right: 2ex ;
-                 border: thin solid #888888; }
-
-/* Examples */
-pre.data	{ border: thin solid #88AA88;
-                  background-color: #E8F0E8;
-                  margin: 1em 4em 1em 0em ; }
-
-pre.dataExcerpt	{ border: thin solid #88AA88;
-                  background-color: #E8F0E8;
-                  margin: 1em 4em 1em 0em ; }
-/* Example Queries */
-.query          { background-color:#f7f8ff; }
-.queryExcerpt   { background-color:#f7f8ff; }
-pre.query	{ border:thin solid #8888aa;
-                  margin: 1em 4em 1em 0em ; }
-/* Example Results */
-.result		{ border: thin solid  #888888 ;
-                  background-color: #F0F0F0 ; }
-pre.resultGraph	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultSet	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultAsk	{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-pre.resultTurtle{  margin: 0em 0em 0em 0em ; /* Top Right Bottom Left */
-                   padding: 0ex;
-                   font-size: 100% ;
-                   page-break-inside: avoid ; }
-
-pre.result	{ margin: 1em 4em 1em 0em ; }
-
-div.result	{ font-family: monospace;
-                  margin:  1em 4em 1em 0em ;
-                  padding: 1ex ; }
-
-.result table	{ border-collapse: collapse; }
-.result table td{ border-width: 1px ;
-                  border-color : black ; 
-                  font-family: monospace ;
-                  empty-cells: show;
-                  padding-left: 1ex ; padding-right: 1ex ;
-                  vertical-align:top;
-                  text-align: left ; } 
-/*  spacing: 0 ;*/
-.result table th{ border-width: 1px ;
-                  font-family: monospace ;
-                  border-color: black ;
-                  empty-cells: show;
-                  padding-left: 1ex ; padding-right: 1ex ;
-                  vertical-align:top;
-                  text-align:center; } 
-
-/* Examples : Algebra */
-div.algExample {  border: thin solid #888888;
-                  page-break-inside: avoid ;
-                  padding:0.5em ; margin:0.5em ;
-                  margin-left: 2em ; margin-right: 2em ;
-                  font-family:monospace ; }
-
-div.algExample1 { padding:0.5em ; background-color: #F0F0FF ; }
-div.algExample2 { padding:0.5em ; margin-top: 0.5em ; background-color: #F0FFF0 ; }
-
-/* Grammar Mark-up */
-.operator	{ color: #3f3f5f;
-                  text-transform: uppercase; }
-.function	{ color: #3f3f5f;
-                }
-
-/* Tuned to cope with different browsers behaviours */
-div.grammarTable table	{ border-style: solid ;
-			  border-width: 1px ;
-			  border-color: #AAA ;
-			  border-spacing: 0px ; 
-			  border-collapse: collapse ; }
-
-div.grammarTable table * { border-left-width: 0px ;
-			   border-right-width: 0px ;
-			   border-color: #AAA ; } 
-
-div.grammarTable table * tr   { border-top-style: solid ;
-			  border-top-width: 1px ;
-			  border-top-color: #AAA ; } 
-
-.grammar	{ text-align: left ;
-                  vertical-align: top ; }
-.token		{ color: #3f3f5f; }
-table.FAndOTable .token		{ color: #00c; }
-table.FAndOTable .token:visited		{ color: #a0c; }
-.gRuleHead	{ font-style: italic ;
-                  font-family: monospace ; }
-.gRuleBody	{ font-family: monospace ; }
-.gRuleLabel	{ font-family: monospace ; }
-
-.code		{ font-family: monospace; font-size: 100%; }
-pre.code	{ font-family: monospace; font-size: 100%; margin: 0 ; }
-
-/* Table of Contents */
-.toc		{ text-indent: 0; }
-DIV.toc UL UL, DIV.toc OL OL {margin-left: 0}
-DIV.toc UL UL UL, DIV.toc OL OL OL {margin-left: 1em}
-DIV.toc UL UL UL UL, DIV.toc OL OL OL OL {margin-left: 0}
-LI.tocline1	{ font-weight: bold}
-LI.tocline2	{ font-weight: normal}
-LI.tocline4	{ font-style: italic}
-/* The border in the following rule crashes NN4 on fonts.html :-(
-DIV.subtoc	{ padding: 1em; border: solid black thin; margin: 1em 0;
-                  background: #ddd} */
-DIV.toc, UL.index, DT { text-align: left; }
-
-
-/* References to the Rdf Data Model */
-span.rdfDM	{ color: #11d; }
-
-
-/* Truth Table */
-  .truth	{ font-family: monospace; }
-  .error	{ color: #ff1f1f; }
-  table.truthTable td	{ text-align: center; font-family: monospace; }
-  table.truthTable th	{ background-color: #dfdfdf; }
-  table.truthTable tbody th	{ font-weight: normal; font-family: monospace; }
-
-/* Casting table */
-table.casting	{ font-size: x-small; }
-
-.castY	{ background-color: #7FFF7F;
-                  color: black; }
-
-.castN	{ background-color: #FF7F7F;
-                  color: black; }
-
-.castM	{ background-color: white;
-                  color: black; }
-
-span.cancast:hover { background-color: #ffa;
-                     color: black; }
-
-.SPARQLoperator	{ background-color: #FFFFbf; /* yellow */
-          }
-
-.owlnonterminal {
-    font-weight: bold;
-    font-family: sans-serif;
-    font-size: 95%;
-}
-.owlgrammar {
-    margin-top: 1ex;
-    margin-bottom: 1ex;
-    padding-left: 1ex;
-    padding-right: 1ex;
-    padding-top: 1ex;
-    padding-bottom: 0.6ex;
-    border: 1px dashed #2f6fab;
-    font-family: monospace;
-}
-
-      /* ReSpec */
-      dfn { font-style: normal ; }
-      /* ReSpec */
-
-  code           { font-family: monospace; }
-
-  div.constraint,
-  div.issue,
-  div.note,
-  div.notice     { margin-left: 2em; }
-
-  ol.enumar      { list-style-type: decimal; }
-  ol.enumla      { list-style-type: lower-alpha; }
-  ol.enumlr      { list-style-type: lower-roman; }
-  ol.enumua      { list-style-type: upper-alpha; }
-  ol.enumur      { list-style-type: upper-roman; }
-
-
-  div.exampleInner pre { margin-left: 1em;
-                       margin-top: 0em; margin-bottom: 0em}
-  div.exampleOuter {border: 4px double gray;
-                  margin: 0em; padding: 0em}
-  div.exampleInner { background-color: #d5dee3;
-                   border-top-width: 4px;
-                   border-top-style: double;
-                   border-top-color: #d3d3d3;
-                   border-bottom-width: 4px;
-                   border-bottom-style: double;
-                   border-bottom-color: #d3d3d3;
-                   padding: 4px; margin: 0em }
-  div.exampleWrapper { margin: 4px }
-  div.exampleHeader { font-weight: bold;
-                    margin: 4px}
-    </style>
   </head>
   <body>
     <section id="abstract">
@@ -360,7 +73,7 @@ span.cancast:hover { background-color: #ffa;
       They provide lowest common denominator formats between systems using different implementation technologies.</p>
     <p>Other formats for expression of SPARQL results are the SPARQL Results XML Format 
       [[SPARQL12-RESULTS-XML]] and 
-      the SPARQL Results JSON Format [[SPARQL12-RESULTS-JSON</a>]]. Each format is useful
+      the SPARQL Results JSON Format [[SPARQL12-RESULTS-JSON]]. Each format is useful
       in different application scenarios.</p>
     <p>The SPARQL Results CSV Format is a lossy encoding of a table of results. It does not encode all the
       details of each RDF term in the results; instead, it just gives a string without indicating the type of the
@@ -382,83 +95,83 @@ span.cancast:hover { background-color: #ffa;
       <section id="example1">
       <h3>Example</h3>
       <p>The following artificial example is used to illustrate the features of serializing results in each format.</p>
-      <table class="result">
+      <table>
         <tbody>
           <tr>
             <th>x</th>
             <th>literal</th>
-            <th class="tablecomment"><i>Comment (not part of the table)</i></th>
+            <th><i>Comment (not part of the table)</i></th>
           </tr>
           <tr>
-            <td>&lt;http://example/x&gt;</td>
-            <td>String</td>
-            <td class="tablecomment">An IRI and a string consisting of characters S-t-r-i-n-g</td>
+            <td><code>&lt;http://example/x&gt;</code></td>
+            <td><code>String</code></td>
+            <td>An IRI and a string consisting of characters S-t-r-i-n-g</td>
           </tr>
           <tr>
-            <td>&lt;http://example/x&gt;</td>
-            <td>String-with-dquote"</td>
-            <td class="tablecomment">String with a double quote in it.</td>
+            <td><code>&lt;http://example/x&gt;</code></td>
+            <td><code>String-with-dquote"</code></td>
+            <td>String with a double quote in it.</td>
           </tr>
           <tr>
-            <td>_:b0</td>
+            <td><code>_:b0</code></td>
+            <td><code>Blank node</code></td>
             <td>Blank node</td>
-            <td class="tablecomment">Blank node</td>
           </tr>
           <tr>
             <td></td>
-            <td>Missing 'x'</td>
-            <td class="tablecomment">No RDF term for the <b>x</b> column</td>
+            <td><code>Missing 'x'</code></td>
+            <td>No RDF term for the <b>x</b> column</td>
           </tr>
           <tr>
             <td></td>
             <td></td>
-            <td class="tablecomment">This row has no terms in it.</td>
+            <td>This row has no terms in it.</td>
           </tr>
           <tr>
-            <td>&lt;http://example/x&gt;</td>
+            <td><code>&lt;http://example/x&gt;</code></td>
             <td></td>
-            <td class="tablecomment">No term in the <b>literal</b> column.</td>
+            <td>No term in the <b>literal</b> column.</td>
           </tr>
           <tr>
-            <td>_:b1</td>
-            <td>"String-with-lang"@en</td>
-            <td class="tablecomment">An RDF literal with a language tag</td>
+            <td><code>_:b1</code></td>
+            <td><code>"String-with-lang"@en</code></td>
+            <td>An RDF literal with a language tag</td>
           </tr>
           <tr>
-            <td>_:b1</td>
-            <td>"String-with-lang-dir"@en--ltr</td>
-            <td class="tablecomment">An RDF literal with a directional language tag</td>
+            <td><code>_:b1</code></td>
+            <td><code>"String-with-lang-dir"@en--ltr</code></td>
+            <td>An RDF literal with a directional language tag</td>
           </tr>
           <tr>
-            <td>_:b1</td>
-            <td>123</td>
-            <td class="tablecomment">An RDF literal, datatype xsd:integer, and lexical form 123.</td>
+            <td><code>_:b1</code></td>
+            <td><code>123</code></td>
+            <td>An RDF literal, datatype xsd:integer, and lexical form 123.</td>
           </tr>
         </tbody>
       </table>
 
       <p>The following artificial example is used to illustrate the features of serializing results containing triple terms.</p>
-      <table class="result">
+      <table>
         <tbody>
           <tr>
             <th>x</th>
             <th>triple</th>
-            <th class="tablecomment"><i>Comment (not part of the table)</i></th>
+            <th><i>Comment (not part of the table)</i></th>
           </tr>
           <tr>
-            <td>"Alice"</td>
-            <td>&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;</td>
-            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/alice</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
+            <td><code>"Alice"</code></td>
+            <td><code>&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;</code></td>
+            <td>A plain string and triple term with subject IRI <code>http://example/alice</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/bob</code>.</td>
           </tr>
           <tr>
-            <td>"Bob"</td>
-            <td>&lt;&lt;( &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; )&gt;&gt;</td>
-            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/bob</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
+            <td><code>"Bob"</code></td>
+            <td><code>&lt;&lt;( &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; )&gt;&gt;</code></td>
+            <td>A plain string and triple term with subject IRI <code>http://example/bob</code>, predicate IRI <code>http://example/knows</code>, and object IRI <code>http://example/alice</code>.</td>
           </tr>
           <tr>
-            <td>"Carol"</td>
-            <td>&lt;&lt;( &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"." )&gt;&gt;</td>
-            <td class="tablecomment">A plain string and triple term with subject IRI <code>http://example/carol</code>, predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
+            <td><code>"Carol"</code></td>
+            <td><code>&lt;&lt;( &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\"." )&gt;&gt;</code></td>
+            <td>A plain string and triple term with subject IRI <code>http://example/carol</code>, predicate IRI <code>http://example/says</code>, and object literal <code>Hello world, my name is "Alice".</code>.</td>
           </tr>
         </tbody>
       </table>
@@ -549,7 +262,7 @@ span.cancast:hover { background-color: #ffa;
     
       <section id="csv-example">
       <h3>Example of CSV-Serialized Results</h3>
-      <pre class="box csv nohighlight">x,literal
+      <pre class="csv">x,literal
 http://example/x,String
 http://example/x,"String-with-dquote"""
 _:b0,Blank node
@@ -563,7 +276,7 @@ _:b1,123</pre>
 
       <section id="csv-example-triple-terms">
       <h3>Example of CSV-Serialized Results with Triple Terms</h3>
-      <pre class="box csv nohighlight">x,triple
+      <pre class="csv">x,triple
 "Alice",&lt;&lt;( http://example/alice http://example/knows http://example/bob )&gt;&gt;
 "Bob",&lt;&lt;( http://example/bob http://example/knows http://example/alice )&gt;&gt;
 "Carol","&lt;&lt;( http://example/carol http://example/says ""Hello world, my name is """"Alice""""."" )&gt;&gt;"</pre>
@@ -629,7 +342,7 @@ _:b1,123</pre>
       <section id="tsv-example">
       <h3>Example of TSV-Serialized Results</h3>
       <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
-      <pre class="box tsv nohighlight">?x&lt;TAB&gt;?literal
+      <pre class="tsv">?x&lt;TAB&gt;?literal
 &lt;http://example/x&gt;&lt;TAB&gt;"String"
 &lt;http://example/x&gt;&lt;TAB&gt;"String-with-dquote\"" 
 <!--  " Unconfuse ...  -->
@@ -646,7 +359,7 @@ _:blank1&lt;TAB&gt;123</pre>
       <section id="tsv-example-triple-terms">
       <h3>Example of TSV-Serialized Results with Triple Terms</h3>
       <p>Writing <code>&lt;TAB&gt;</code> for a raw tab character (Unicode code point <code>U+0009</code>):</p>
-      <pre class="box tsv nohighlight">?x&lt;TAB&gt;?triple
+      <pre class="tsv">?x&lt;TAB&gt;?triple
 "Alice"&lt;TAB&gt;&lt;&lt;( &lt;http://example/alice&gt; &lt;http://example/knows&gt; &lt;http://example/bob&gt; )&gt;&gt;
 "Bob"&lt;TAB&gt;&lt;&lt;( &lt;http://example/bob&gt; &lt;http://example/knows&gt; &lt;http://example/alice&gt; )&gt;&gt;
 "Carol"&lt;TAB&gt;&lt;&lt;( &lt;http://example/carol&gt; &lt;http://example/says&gt; "Hello world, my name is \"Alice\". )&gt;&gt;</pre>


### PR DESCRIPTION
- remove class="box", the code already has a different background color
- simplify the table style to be closer to ReSpec
- add explicit `code` tags in the table
- drop the style block that is unused


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/pull/42.html" title="Last updated on May 21, 2026, 4:47 PM UTC (f4184eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-csv-tsv/42/dc43d29...f4184eb.html" title="Last updated on May 21, 2026, 4:47 PM UTC (f4184eb)">Diff</a>